### PR TITLE
feat: bootstrap FastAPI and MCP runtime foundation (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.so
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: run test lint format
+
+run:
+	python3.11 -m openapi_to_mcp.main
+
+test:
+	python3.11 -m pytest -q
+
+lint:
+	python3.11 -m ruff check src tests
+
+format:
+	python3.11 -m ruff check --fix src tests

--- a/docs/adr/0001-python-fastapi-fastmcp-bootstrap.md
+++ b/docs/adr/0001-python-fastapi-fastmcp-bootstrap.md
@@ -1,0 +1,77 @@
+# ADR 0001: Python FastAPI and FastMCP Bootstrap
+
+- Status: Accepted
+- Date: 2026-02-21
+- Parent issue: [#1](https://github.com/Albe83/openapi-to-mcp/issues/1)
+- Related sub-issues: [#2](https://github.com/Albe83/openapi-to-mcp/issues/2), [#3](https://github.com/Albe83/openapi-to-mcp/issues/3), [#4](https://github.com/Albe83/openapi-to-mcp/issues/4), [#5](https://github.com/Albe83/openapi-to-mcp/issues/5), [#6](https://github.com/Albe83/openapi-to-mcp/issues/6), [#7](https://github.com/Albe83/openapi-to-mcp/issues/7), [#8](https://github.com/Albe83/openapi-to-mcp/issues/8), [#9](https://github.com/Albe83/openapi-to-mcp/issues/9), [#10](https://github.com/Albe83/openapi-to-mcp/issues/10), [#11](https://github.com/Albe83/openapi-to-mcp/issues/11)
+
+## Context
+The repository has governance and documentation, but no runnable application code.
+The first increment must provide a real technical foundation that can load an OpenAPI contract and expose mapped tools through MCP over HTTP streamable transport.
+
+## Decision
+Use Python with FastAPI and FastMCP.
+Adopt a Hexagonal Architecture shape with explicit ports and adapters:
+- Inbound: FastAPI/FastMCP transport adapter.
+- Application services: startup orchestration, operation mapping, tool generation.
+- Outbound: OpenAPI source loaders and downstream HTTP invoker.
+
+Configuration is environment driven:
+- `OPENAPI_SPEC_PATH`
+- `OPENAPI_SPEC_URL`
+- `MCP_HOST`
+- `MCP_PORT`
+- `LOG_LEVEL`
+
+Tool naming rule:
+- First choice: `operationId`.
+- Fallback: deterministic `<method>_<sanitized_path>`.
+
+Validation rule:
+- Fail fast for critical OpenAPI contract errors.
+- Keep warning-only behavior for non-critical metadata quality issues.
+
+Server resolution rule:
+- Resolve server URL in this order: operation -> path -> root.
+- If no server URL is resolvable for an operation, fail startup.
+
+## DDD Assessment
+DDD is applicable because this increment introduces domain models for operations and generated tools.
+
+### Ubiquitous Language
+- Operation: one executable REST API action from OpenAPI.
+- Generated Tool: MCP tool produced from one Operation.
+- Port: interface that isolates domain/application from frameworks or IO.
+- Adapter: concrete implementation of a Port.
+
+### Bounded Context
+- Context name: `Tool Generation Context`.
+- Boundary: from OpenAPI contract ingestion to MCP tool registration and invocation wiring.
+
+### Aggregates and Invariants
+- Aggregate root: `ApiOperation`.
+  - Invariant: method and path must be present.
+- Aggregate root: `GeneratedTool`.
+  - Invariant: tool name must be deterministic and not empty.
+- Aggregate root: `GenerationReport`.
+  - Invariant: generated + skipped equals total input operations processed.
+
+## Alternatives Considered
+1. Go + custom MCP integration.
+   - Rejected for first increment due slower bootstrap.
+2. Python without Hexagonal boundaries.
+   - Rejected due coupling risk and weaker testability.
+3. Best-effort validation only.
+   - Rejected because startup should fail on invalid critical contracts.
+
+## Consequences and Tradeoffs
+- Positive: clear testable boundaries, faster bootstrap, policy compliance.
+- Negative: more files and abstractions in first increment.
+- Risk: FastMCP API evolution can break integration; mitigated by transport adapter isolation.
+
+## Required Artifact Links
+- Class diagram: [docs/diagrams/0002-class-bootstrap-core.md](../diagrams/0002-class-bootstrap-core.md)
+- Sequence diagram: [docs/diagrams/0003-sequence-startup-and-tool-call.md](../diagrams/0003-sequence-startup-and-tool-call.md)
+- Hexagonal diagram: [docs/diagrams/0004-hexagonal-bootstrap-boundaries.md](../diagrams/0004-hexagonal-bootstrap-boundaries.md)
+- Public API IDL: [docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml](../interfaces/0001-openapi-to-mcp-server-openapi.yaml)
+- Domain schema: [docs/schemas/0001-core-domain-models.schema.yaml](../schemas/0001-core-domain-models.schema.yaml)

--- a/docs/diagrams/0002-class-bootstrap-core.md
+++ b/docs/diagrams/0002-class-bootstrap-core.md
@@ -1,0 +1,87 @@
+# Class Diagram - Bootstrap Core
+
+- Parent issue: [#1](https://github.com/Albe83/openapi-to-mcp/issues/1)
+- ADR: [docs/adr/0001-python-fastapi-fastmcp-bootstrap.md](../adr/0001-python-fastapi-fastmcp-bootstrap.md)
+- Purpose: Show the core domain, ports, and adapters for startup and runtime mapping.
+
+```mermaid
+classDiagram
+  class Settings {
+    +openapi_spec_path: str?
+    +openapi_spec_url: str?
+    +mcp_host: str
+    +mcp_port: int
+    +log_level: str
+    +validate()
+  }
+
+  class ApiOperation {
+    +method: str
+    +path: str
+    +operation_id: str?
+    +summary: str?
+    +parameters: list
+    +request_body_schema: object?
+  }
+
+  class GeneratedTool {
+    +name: str
+    +description: str
+    +input_schema: object
+    +binding: object
+  }
+
+  class GenerationReport {
+    +generated_count: int
+    +skipped_count: int
+    +errors: list
+    +warnings: list
+  }
+
+  class OpenApiSourcePort {
+    <<interface>>
+    +load_raw() dict
+  }
+
+  class OpenApiValidatorPort {
+    <<interface>>
+    +validate(raw) dict
+  }
+
+  class OperationMapper {
+    +map_operations(spec) list~ApiOperation~
+  }
+
+  class ToolGenerationService {
+    +generate(operations) tuple~list~GeneratedTool~, GenerationReport~
+  }
+
+  class HttpInvokerPort {
+    <<interface>>
+    +invoke(binding, payload) object
+  }
+
+  class FastMcpAdapter {
+    +register_tools(tools)
+    +mount_http_transport(app)
+  }
+
+  class StartupOrchestrator {
+    +bootstrap() GenerationReport
+  }
+
+  Settings --> StartupOrchestrator
+  OpenApiSourcePort <|.. FileOpenApiSourceAdapter
+  OpenApiSourcePort <|.. UrlOpenApiSourceAdapter
+  OpenApiValidatorPort <|.. OpenApiValidatorAdapter
+  HttpInvokerPort <|.. HttpxInvokerAdapter
+  StartupOrchestrator --> OpenApiSourcePort
+  StartupOrchestrator --> OpenApiValidatorPort
+  StartupOrchestrator --> OperationMapper
+  StartupOrchestrator --> ToolGenerationService
+  StartupOrchestrator --> FastMcpAdapter
+  FastMcpAdapter --> HttpInvokerPort
+  ToolGenerationService --> GeneratedTool
+  ToolGenerationService --> GenerationReport
+  OperationMapper --> ApiOperation
+```

--- a/docs/diagrams/0003-sequence-startup-and-tool-call.md
+++ b/docs/diagrams/0003-sequence-startup-and-tool-call.md
@@ -1,0 +1,38 @@
+# Sequence Diagram - Startup and Tool Call
+
+- Parent issue: [#1](https://github.com/Albe83/openapi-to-mcp/issues/1)
+- ADR: [docs/adr/0001-python-fastapi-fastmcp-bootstrap.md](../adr/0001-python-fastapi-fastmcp-bootstrap.md)
+- Purpose: Show startup bootstrap flow and tool invocation flow.
+
+```mermaid
+sequenceDiagram
+  participant Runtime as App Runtime
+  participant Config as Settings Loader
+  participant Source as OpenApiSourcePort Adapter
+  participant Validator as OpenApiValidatorPort Adapter
+  participant Mapper as OperationMapper
+  participant Generator as ToolGenerationService
+  participant MCP as FastMcpAdapter
+  participant HTTP as HttpInvokerPort Adapter
+
+  Runtime->>Config: load env configuration
+  Config-->>Runtime: Settings
+  Runtime->>Source: load_raw()
+  Source-->>Runtime: Raw OpenAPI
+  Runtime->>Validator: validate(raw)
+  Validator-->>Runtime: Validated OpenAPI
+  Runtime->>Mapper: map_operations(spec)
+  Mapper-->>Runtime: ApiOperation[]
+  Runtime->>Generator: generate(operations)
+  Generator-->>Runtime: GeneratedTool[] + GenerationReport
+  Runtime->>MCP: register_tools(generated_tools)
+  MCP-->>Runtime: registration complete
+
+  Note over Runtime,MCP: Runtime ready and MCP endpoint exposed
+
+  participant Agent as AI Agent
+  Agent->>MCP: tool call(name, input)
+  MCP->>HTTP: invoke(binding, input)
+  HTTP-->>MCP: downstream REST response
+  MCP-->>Agent: tool result payload
+```

--- a/docs/diagrams/0004-hexagonal-bootstrap-boundaries.md
+++ b/docs/diagrams/0004-hexagonal-bootstrap-boundaries.md
@@ -1,0 +1,52 @@
+# Hexagonal Diagram - Bootstrap Boundaries
+
+- Parent issue: [#1](https://github.com/Albe83/openapi-to-mcp/issues/1)
+- ADR: [docs/adr/0001-python-fastapi-fastmcp-bootstrap.md](../adr/0001-python-fastapi-fastmcp-bootstrap.md)
+- Purpose: Show inbound and outbound ports/adapters and dependency direction.
+
+```mermaid
+flowchart LR
+  subgraph InboundAdapters[Inbound Adapters]
+    FastAPI[FastAPI App]
+    FastMCP[FastMCP Transport]
+  end
+
+  subgraph Core[Application and Domain Core]
+    Orchestrator[StartupOrchestrator]
+    Mapper[OperationMapper]
+    Generator[ToolGenerationService]
+    Domain[(ApiOperation / GeneratedTool / GenerationReport)]
+    SourcePort[[OpenApiSourcePort]]
+    ValidatorPort[[OpenApiValidatorPort]]
+    InvokerPort[[HttpInvokerPort]]
+  end
+
+  subgraph OutboundAdapters[Outbound Adapters]
+    FileLoader[FileOpenApiSourceAdapter]
+    UrlLoader[UrlOpenApiSourceAdapter]
+    Validator[OpenApiValidatorAdapter]
+    HttpxInvoker[HttpxInvokerAdapter]
+    RemoteApi[(Target REST API)]
+  end
+
+  FastAPI --> Orchestrator
+  FastMCP --> Orchestrator
+
+  Orchestrator --> SourcePort
+  Orchestrator --> ValidatorPort
+  Orchestrator --> Mapper
+  Orchestrator --> Generator
+  Generator --> Domain
+  Mapper --> Domain
+
+  SourcePort --> FileLoader
+  SourcePort --> UrlLoader
+  ValidatorPort --> Validator
+  InvokerPort --> HttpxInvoker
+  HttpxInvoker --> RemoteApi
+
+  note1[Dependencies point inward to Core]:::note
+  note2[External systems isolated by ports/adapters]:::note
+
+  classDef note fill:#f5f5f5,stroke:#666,stroke-width:1px,color:#222;
+```

--- a/docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml
+++ b/docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml
@@ -1,0 +1,52 @@
+openapi: 3.1.0
+info:
+  title: OpenAPI to MCP Service API
+  version: 0.1.0
+  description: |
+    Public API contract for the OpenAPI-to-MCP runtime service.
+    Parent issue: #1
+    Related ADR: docs/adr/0001-python-fastapi-fastmcp-bootstrap.md
+    Change type: New public API
+servers:
+  - url: http://localhost:8080
+paths:
+  /healthz:
+    get:
+      summary: Liveness and readiness probe
+      operationId: getHealth
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status:
+                    type: string
+                    enum: [ok]
+  /mcp:
+    post:
+      summary: Streamable HTTP entrypoint for MCP messages
+      operationId: postMcpMessage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: MCP JSON-RPC request envelope
+              additionalProperties: true
+      responses:
+        '200':
+          description: MCP response payload
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid MCP request
+        '500':
+          description: Internal server error

--- a/docs/schemas/0001-core-domain-models.schema.yaml
+++ b/docs/schemas/0001-core-domain-models.schema.yaml
@@ -1,0 +1,72 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: OpenAPI to MCP Core Domain Models
+description: |
+  Formal schema for core domain model artifacts introduced in bootstrap.
+  Parent issue: #1
+  Related ADR: docs/adr/0001-python-fastapi-fastmcp-bootstrap.md
+type: object
+required: [apiOperation, generatedTool, generationReport]
+properties:
+  apiOperation:
+    type: object
+    required: [method, path]
+    properties:
+      method:
+        type: string
+      path:
+        type: string
+      operationId:
+        type: string
+      summary:
+        type: string
+      parameters:
+        type: array
+        items:
+          type: object
+          additionalProperties: true
+      requestBodySchema:
+        type: object
+        additionalProperties: true
+    additionalProperties: false
+  generatedTool:
+    type: object
+    required: [name, description, inputSchema, binding]
+    properties:
+      name:
+        type: string
+        minLength: 1
+      description:
+        type: string
+      inputSchema:
+        type: object
+        additionalProperties: true
+      binding:
+        type: object
+        required: [method, path]
+        properties:
+          method:
+            type: string
+          path:
+            type: string
+        additionalProperties: true
+    additionalProperties: false
+  generationReport:
+    type: object
+    required: [generatedCount, skippedCount, errors, warnings]
+    properties:
+      generatedCount:
+        type: integer
+        minimum: 0
+      skippedCount:
+        type: integer
+        minimum: 0
+      errors:
+        type: array
+        items:
+          type: string
+      warnings:
+        type: array
+        items:
+          type: string
+    additionalProperties: false
+additionalProperties: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openapi-to-mcp"
+version = "0.1.0"
+description = "Expose generic REST APIs as MCP tools from OpenAPI contracts"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "OpenAPI to MCP Maintainers" }]
+dependencies = [
+  "fastapi>=0.116.0",
+  "httpx>=0.28.0",
+  "pydantic>=2.8.0",
+  "pyyaml>=6.0.0",
+  "uvicorn>=0.30.0",
+]
+
+[project.optional-dependencies]
+mcp = ["mcp>=1.0.0"]
+dev = [
+  "pytest>=8.3.0",
+  "ruff>=0.8.0",
+]
+
+[project.scripts]
+openapi-to-mcp = "openapi_to_mcp.main:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
+ignore = []

--- a/src/openapi_to_mcp/__init__.py
+++ b/src/openapi_to_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""OpenAPI to MCP bootstrap package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/openapi_to_mcp/adapters/__init__.py
+++ b/src/openapi_to_mcp/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage."""

--- a/src/openapi_to_mcp/adapters/http_invoker.py
+++ b/src/openapi_to_mcp/adapters/http_invoker.py
@@ -1,0 +1,91 @@
+"""HTTP invocation adapter for downstream REST calls."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+from urllib.parse import quote
+
+import httpx
+
+from openapi_to_mcp.errors import InvocationError
+
+
+class HttpxInvokerAdapter:
+    """Invoke downstream REST operations using HTTPX."""
+
+    def __init__(
+        self,
+        timeout_seconds: float = 10.0,
+        client_factory: Optional[Callable[[], httpx.AsyncClient]] = None,
+    ) -> None:
+        self._timeout_seconds = timeout_seconds
+        self._client_factory = client_factory
+
+    async def invoke(self, binding: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+        method = str(binding.get("method", "")).upper()
+        path = str(binding.get("path", ""))
+        server_url = str(binding.get("server_url", "")).strip()
+
+        if not method or not path:
+            raise InvocationError("Invalid binding: missing method or path.")
+
+        url_path = _render_path(path, binding.get("path_params", []), payload)
+        url = _build_url(server_url, url_path)
+
+        query_params = {
+            name: payload[name]
+            for name in binding.get("query_params", [])
+            if name in payload and payload[name] is not None
+        }
+        headers = {
+            name: str(payload[name])
+            for name in binding.get("header_params", [])
+            if name in payload and payload[name] is not None
+        }
+        json_body = payload.get("body")
+
+        async with self._make_client() as client:
+            try:
+                response = await client.request(
+                    method=method,
+                    url=url,
+                    params=query_params,
+                    headers=headers,
+                    json=json_body,
+                )
+            except httpx.HTTPError as exc:
+                raise InvocationError(f"HTTP invocation failed for {method} {url}.") from exc
+
+        body: Any
+        try:
+            body = response.json()
+        except ValueError:
+            body = response.text
+
+        return {
+            "status_code": response.status_code,
+            "headers": dict(response.headers),
+            "body": body,
+        }
+
+    def _make_client(self) -> httpx.AsyncClient:
+        if self._client_factory is not None:
+            return self._client_factory()
+        return httpx.AsyncClient(timeout=self._timeout_seconds)
+
+
+def _build_url(server_url: str, path: str) -> str:
+    if path.startswith("http://") or path.startswith("https://"):
+        return path
+    if not server_url:
+        raise InvocationError("No server_url available for relative path invocation.")
+    return f"{server_url.rstrip('/')}{path}"
+
+
+def _render_path(path: str, path_params: list[str], payload: Dict[str, Any]) -> str:
+    rendered = path
+    for key in path_params:
+        if key not in payload:
+            raise InvocationError(f"Missing required path parameter: {key}")
+        rendered = rendered.replace(f"{{{key}}}", quote(str(payload[key]), safe=""))
+    return rendered

--- a/src/openapi_to_mcp/adapters/openapi_source.py
+++ b/src/openapi_to_mcp/adapters/openapi_source.py
@@ -1,0 +1,67 @@
+"""OpenAPI source adapters for file and URL inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+import httpx
+import yaml
+
+from openapi_to_mcp.errors import SourceLoadError
+
+
+class FileOpenApiSourceAdapter:
+    """Load an OpenAPI document from local filesystem."""
+
+    def __init__(self, path: str) -> None:
+        self._path = Path(path)
+
+    def load_raw(self) -> Dict[str, Any]:
+        if not self._path.exists() or not self._path.is_file():
+            raise SourceLoadError(f"OpenAPI file not found: {self._path}")
+
+        try:
+            raw_text = self._path.read_text(encoding="utf-8")
+            loaded = yaml.safe_load(raw_text)
+        except OSError as exc:
+            raise SourceLoadError(f"Cannot read OpenAPI file: {self._path}") from exc
+        except yaml.YAMLError as exc:
+            raise SourceLoadError(f"Invalid YAML/JSON in OpenAPI file: {self._path}") from exc
+
+        if not isinstance(loaded, dict):
+            raise SourceLoadError("OpenAPI file content must be an object.")
+        return loaded
+
+
+class UrlOpenApiSourceAdapter:
+    """Load an OpenAPI document from remote URL."""
+
+    def __init__(
+        self,
+        url: str,
+        timeout_seconds: float = 10.0,
+        fetcher: Optional[Callable[[str], Dict[str, Any]]] = None,
+    ) -> None:
+        self._url = url
+        self._timeout_seconds = timeout_seconds
+        self._fetcher = fetcher
+
+    def load_raw(self) -> Dict[str, Any]:
+        if self._fetcher is not None:
+            return self._fetcher(self._url)
+
+        try:
+            response = httpx.get(self._url, timeout=self._timeout_seconds)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise SourceLoadError(f"Cannot fetch OpenAPI URL: {self._url}") from exc
+
+        try:
+            loaded = yaml.safe_load(response.text)
+        except yaml.YAMLError as exc:
+            raise SourceLoadError(f"Invalid YAML/JSON from URL: {self._url}") from exc
+
+        if not isinstance(loaded, dict):
+            raise SourceLoadError("OpenAPI URL content must be an object.")
+        return loaded

--- a/src/openapi_to_mcp/adapters/openapi_validator.py
+++ b/src/openapi_to_mcp/adapters/openapi_validator.py
@@ -1,0 +1,79 @@
+"""OpenAPI validation adapter with strict critical checks."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List
+
+from openapi_to_mcp.errors import OpenApiValidationError
+from openapi_to_mcp.ports import OpenApiValidationResult
+
+_ALLOWED_HTTP_METHODS = {
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "options",
+    "head",
+    "trace",
+}
+
+
+class OpenApiValidatorAdapter:
+    """Validate critical OpenAPI structure and emit non-fatal warnings."""
+
+    def validate(self, raw_spec: Dict[str, Any]) -> OpenApiValidationResult:
+        if not isinstance(raw_spec, dict):
+            raise OpenApiValidationError("OpenAPI content must be an object.")
+
+        spec = deepcopy(raw_spec)
+        warnings: List[str] = []
+
+        openapi_version = spec.get("openapi")
+        if not isinstance(openapi_version, str) or not openapi_version.strip():
+            raise OpenApiValidationError("Missing or invalid 'openapi' version.")
+
+        paths = spec.get("paths")
+        if not isinstance(paths, dict) or not paths:
+            raise OpenApiValidationError("Missing or invalid 'paths' section.")
+
+        root_server_url = _extract_first_server_url(spec.get("servers"))
+        for path, path_item in paths.items():
+            if not isinstance(path, str) or not path.startswith("/"):
+                raise OpenApiValidationError("Each path key must be a string starting with '/'.")
+            if not isinstance(path_item, dict):
+                raise OpenApiValidationError(f"Path item must be an object for '{path}'.")
+
+            path_server_url = _extract_first_server_url(path_item.get("servers"))
+            for method, operation in path_item.items():
+                if method not in _ALLOWED_HTTP_METHODS:
+                    # Non-method keys such as parameters are allowed at path-item level.
+                    continue
+                if not isinstance(operation, dict):
+                    raise OpenApiValidationError(
+                        f"Operation '{method.upper()} {path}' must be an object."
+                    )
+                if not operation.get("operationId"):
+                    warnings.append(f"Missing operationId for {method.upper()} {path}.")
+                operation_server_url = _extract_first_server_url(operation.get("servers"))
+                resolved_server_url = operation_server_url or path_server_url or root_server_url
+                if not resolved_server_url:
+                    raise OpenApiValidationError(
+                        f"Missing server URL for operation '{method.upper()} {path}'. "
+                        "Define servers at operation, path, or root level."
+                    )
+
+        return OpenApiValidationResult(spec=spec, warnings=warnings)
+
+
+def _extract_first_server_url(servers: Any) -> str | None:
+    if not isinstance(servers, list) or not servers:
+        return None
+    first = servers[0]
+    if not isinstance(first, dict):
+        return None
+    url = first.get("url")
+    if isinstance(url, str) and url.strip():
+        return url.strip()
+    return None

--- a/src/openapi_to_mcp/application/__init__.py
+++ b/src/openapi_to_mcp/application/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage."""

--- a/src/openapi_to_mcp/application/mapper.py
+++ b/src/openapi_to_mcp/application/mapper.py
@@ -1,0 +1,117 @@
+"""Map validated OpenAPI documents to domain operations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from openapi_to_mcp.domain.models import ApiOperation
+
+_ALLOWED_HTTP_METHODS = {
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "options",
+    "head",
+    "trace",
+}
+
+
+class OperationMapper:
+    """Translate OpenAPI path/operation objects into ApiOperation models."""
+
+    def map_operations(self, spec: Dict[str, Any]) -> List[ApiOperation]:
+        paths = spec.get("paths", {})
+        root_server_url = _extract_first_server_url(spec.get("servers"))
+        mapped: List[ApiOperation] = []
+
+        for path, path_item in paths.items():
+            if not isinstance(path_item, dict):
+                continue
+
+            path_server_url = _extract_first_server_url(path_item.get("servers"))
+            path_level_parameters = _extract_parameters(path_item.get("parameters", []))
+
+            for method, operation in path_item.items():
+                if method not in _ALLOWED_HTTP_METHODS or not isinstance(operation, dict):
+                    continue
+
+                op_parameters = _extract_parameters(operation.get("parameters", []))
+                merged_parameters = _merge_parameters(path_level_parameters, op_parameters)
+
+                mapped.append(
+                    ApiOperation(
+                        method=method,
+                        path=path,
+                        operation_id=operation.get("operationId"),
+                        summary=operation.get("summary") or operation.get("description"),
+                        parameters=merged_parameters,
+                        request_body_schema=_extract_request_body_schema(operation),
+                        request_body_required=bool(
+                            operation.get("requestBody", {}).get("required", False)
+                        ),
+                        server_url=_resolve_server_url(operation, path_server_url, root_server_url),
+                    )
+                )
+
+        return mapped
+
+
+def _extract_first_server_url(servers: Any) -> str | None:
+    if not isinstance(servers, list) or not servers:
+        return None
+    first = servers[0]
+    if not isinstance(first, dict):
+        return None
+    value = first.get("url")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _resolve_server_url(
+    operation: Dict[str, Any], path_server_url: str | None, root_server_url: str | None
+) -> str | None:
+    operation_server_url = _extract_first_server_url(operation.get("servers"))
+    return operation_server_url or path_server_url or root_server_url
+
+
+def _extract_parameters(raw_parameters: Any) -> List[Dict[str, Any]]:
+    if not isinstance(raw_parameters, list):
+        return []
+    return [p for p in raw_parameters if isinstance(p, dict)]
+
+
+def _merge_parameters(
+    path_level: List[Dict[str, Any]],
+    operation_level: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    merged: Dict[tuple[str, str], Dict[str, Any]] = {}
+    for candidate in path_level + operation_level:
+        name = str(candidate.get("name", ""))
+        where = str(candidate.get("in", ""))
+        if not name or not where:
+            continue
+        merged[(name, where)] = candidate
+    return list(merged.values())
+
+
+def _extract_request_body_schema(operation: Dict[str, Any]) -> Dict[str, Any] | None:
+    request_body = operation.get("requestBody")
+    if not isinstance(request_body, dict):
+        return None
+
+    content = request_body.get("content")
+    if not isinstance(content, dict):
+        return None
+
+    if "application/json" in content and isinstance(content["application/json"], dict):
+        schema = content["application/json"].get("schema")
+        if isinstance(schema, dict):
+            return schema
+
+    for media_entry in content.values():
+        if isinstance(media_entry, dict) and isinstance(media_entry.get("schema"), dict):
+            return media_entry["schema"]
+    return None

--- a/src/openapi_to_mcp/application/startup.py
+++ b/src/openapi_to_mcp/application/startup.py
@@ -1,0 +1,31 @@
+"""Startup orchestration service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from openapi_to_mcp.application.mapper import OperationMapper
+from openapi_to_mcp.application.tool_generator import ToolGenerationService
+from openapi_to_mcp.domain.models import GenerationReport
+from openapi_to_mcp.ports import OpenApiSourcePort, OpenApiValidatorPort
+from openapi_to_mcp.transport.fastmcp_adapter import FastMcpAdapter
+
+
+@dataclass
+class StartupOrchestrator:
+    """Coordinates bootstrap sequence from spec loading to tool registration."""
+
+    source: OpenApiSourcePort
+    validator: OpenApiValidatorPort
+    mapper: OperationMapper
+    generator: ToolGenerationService
+    mcp_adapter: FastMcpAdapter
+
+    def bootstrap(self) -> GenerationReport:
+        raw_spec = self.source.load_raw()
+        validation = self.validator.validate(raw_spec)
+        operations = self.mapper.map_operations(validation.spec)
+        generated_tools, report = self.generator.generate(operations)
+        report.warnings.extend(validation.warnings)
+        self.mcp_adapter.register_tools(generated_tools)
+        return report

--- a/src/openapi_to_mcp/application/tool_generator.py
+++ b/src/openapi_to_mcp/application/tool_generator.py
@@ -1,0 +1,122 @@
+"""Generate MCP tools from mapped OpenAPI operations."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Tuple
+
+from openapi_to_mcp.domain.models import ApiOperation, GeneratedTool, GenerationReport
+
+
+class ToolGenerationService:
+    """Generate tool contracts and invocation bindings."""
+
+    def generate(
+        self, operations: List[ApiOperation]
+    ) -> Tuple[List[GeneratedTool], GenerationReport]:
+        tools: List[GeneratedTool] = []
+        report = GenerationReport()
+        seen_names: set[str] = set()
+
+        for operation in operations:
+            tool_name = _build_tool_name(operation)
+            if tool_name in seen_names:
+                report.skipped_count += 1
+                report.errors.append(
+                    f"Duplicate tool name '{tool_name}' "
+                    f"for {operation.method.upper()} {operation.path}."
+                )
+                continue
+
+            seen_names.add(tool_name)
+            tools.append(
+                GeneratedTool(
+                    name=tool_name,
+                    description=_build_description(operation),
+                    input_schema=_build_input_schema(operation),
+                    binding=_build_binding(operation),
+                )
+            )
+            report.generated_count += 1
+
+        return tools, report
+
+
+def _build_tool_name(operation: ApiOperation) -> str:
+    if operation.operation_id:
+        return _sanitize_identifier(operation.operation_id)
+    return f"{operation.method.lower()}_{_sanitize_path(operation.path)}"
+
+
+def _build_description(operation: ApiOperation) -> str:
+    if operation.summary:
+        return operation.summary
+    return f"Invoke {operation.method.upper()} {operation.path}"
+
+
+def _build_input_schema(operation: ApiOperation) -> Dict[str, Any]:
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+
+    for parameter in operation.parameters:
+        name = parameter.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+
+        schema = parameter.get("schema")
+        if not isinstance(schema, dict):
+            schema = {"type": "string"}
+
+        properties[name] = schema
+        if parameter.get("required") is True:
+            required.append(name)
+
+    if operation.request_body_schema is not None:
+        properties["body"] = operation.request_body_schema
+        if operation.request_body_required:
+            required.append("body")
+
+    output: Dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        output["required"] = sorted(set(required))
+    return output
+
+
+def _build_binding(operation: ApiOperation) -> Dict[str, Any]:
+    path_params = []
+    query_params = []
+    header_params = []
+
+    for parameter in operation.parameters:
+        name = parameter.get("name")
+        where = parameter.get("in")
+        if not isinstance(name, str) or not isinstance(where, str):
+            continue
+        if where == "path":
+            path_params.append(name)
+        elif where == "query":
+            query_params.append(name)
+        elif where == "header":
+            header_params.append(name)
+
+    return {
+        "method": operation.method,
+        "path": operation.path,
+        "server_url": operation.server_url,
+        "path_params": path_params,
+        "query_params": query_params,
+        "header_params": header_params,
+    }
+
+
+def _sanitize_identifier(value: str) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9_]+", "_", value.strip())
+    normalized = re.sub(r"_+", "_", normalized)
+    return normalized.strip("_") or "tool"
+
+
+def _sanitize_path(path: str) -> str:
+    transformed = path.strip("/")
+    transformed = transformed.replace("{", "by_").replace("}", "")
+    transformed = transformed.replace("/", "_")
+    return _sanitize_identifier(transformed or "root")

--- a/src/openapi_to_mcp/config.py
+++ b/src/openapi_to_mcp/config.py
@@ -1,0 +1,65 @@
+"""Environment-driven runtime configuration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from .errors import ConfigurationError
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime settings loaded from environment variables."""
+
+    openapi_spec_path: Optional[str]
+    openapi_spec_url: Optional[str]
+    mcp_host: str = "0.0.0.0"
+    mcp_port: int = 8080
+    log_level: str = "info"
+
+    @classmethod
+    def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "Settings":
+        values = env or os.environ
+        settings = cls(
+            openapi_spec_path=_normalize_optional(values.get("OPENAPI_SPEC_PATH")),
+            openapi_spec_url=_normalize_optional(values.get("OPENAPI_SPEC_URL")),
+            mcp_host=values.get("MCP_HOST", "0.0.0.0"),
+            mcp_port=_parse_port(values.get("MCP_PORT", "8080")),
+            log_level=values.get("LOG_LEVEL", "info").strip().lower(),
+        )
+        settings.validate()
+        return settings
+
+    def validate(self) -> None:
+        if not self.openapi_spec_path and not self.openapi_spec_url:
+            raise ConfigurationError(
+                "At least one of OPENAPI_SPEC_PATH or OPENAPI_SPEC_URL must be set."
+            )
+        if self.mcp_port <= 0 or self.mcp_port > 65535:
+            raise ConfigurationError("MCP_PORT must be in range 1..65535.")
+        if not self.mcp_host.strip():
+            raise ConfigurationError("MCP_HOST must not be empty.")
+
+    def resolve_openapi_source(self) -> tuple[str, str]:
+        """Resolve source type and value with path precedence when both are set."""
+        if self.openapi_spec_path:
+            return ("path", self.openapi_spec_path)
+        if self.openapi_spec_url:
+            return ("url", self.openapi_spec_url)
+        raise ConfigurationError("No OpenAPI source configured.")
+
+
+def _normalize_optional(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _parse_port(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ConfigurationError("MCP_PORT must be an integer.") from exc

--- a/src/openapi_to_mcp/domain/__init__.py
+++ b/src/openapi_to_mcp/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage."""

--- a/src/openapi_to_mcp/domain/models.py
+++ b/src/openapi_to_mcp/domain/models.py
@@ -1,0 +1,40 @@
+"""Domain models for OpenAPI operation mapping and tool generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class ApiOperation:
+    """A normalized representation of one API operation."""
+
+    method: str
+    path: str
+    operation_id: Optional[str]
+    summary: Optional[str]
+    parameters: List[Dict[str, Any]]
+    request_body_schema: Optional[Dict[str, Any]]
+    request_body_required: bool
+    server_url: Optional[str]
+
+
+@dataclass(frozen=True)
+class GeneratedTool:
+    """A generated MCP tool contract and invocation binding."""
+
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+    binding: Dict[str, Any]
+
+
+@dataclass
+class GenerationReport:
+    """Tool generation summary."""
+
+    generated_count: int = 0
+    skipped_count: int = 0
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)

--- a/src/openapi_to_mcp/errors.py
+++ b/src/openapi_to_mcp/errors.py
@@ -1,0 +1,25 @@
+"""Project-specific exceptions."""
+
+
+class OpenApiToMcpError(Exception):
+    """Base exception for application errors."""
+
+
+class ConfigurationError(OpenApiToMcpError):
+    """Raised when runtime configuration is invalid."""
+
+
+class SourceLoadError(OpenApiToMcpError):
+    """Raised when OpenAPI source loading fails."""
+
+
+class OpenApiValidationError(OpenApiToMcpError):
+    """Raised when critical OpenAPI validation fails."""
+
+
+class InvocationError(OpenApiToMcpError):
+    """Raised when downstream invocation fails."""
+
+
+class ToolRegistrationError(OpenApiToMcpError):
+    """Raised when MCP tool registration fails."""

--- a/src/openapi_to_mcp/main.py
+++ b/src/openapi_to_mcp/main.py
@@ -1,0 +1,18 @@
+"""Application entrypoint."""
+
+from __future__ import annotations
+
+import uvicorn
+
+from openapi_to_mcp.config import Settings
+from openapi_to_mcp.transport.app import create_app
+
+
+def main() -> None:
+    settings = Settings.from_env()
+    app = create_app(settings)
+    uvicorn.run(app, host=settings.mcp_host, port=settings.mcp_port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openapi_to_mcp/ports.py
+++ b/src/openapi_to_mcp/ports.py
@@ -1,0 +1,35 @@
+"""Hexagonal ports for IO and integration boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Protocol
+
+
+@dataclass(frozen=True)
+class OpenApiValidationResult:
+    """Validation output with normalized spec and non-fatal warnings."""
+
+    spec: Dict[str, Any]
+    warnings: List[str] = field(default_factory=list)
+
+
+class OpenApiSourcePort(Protocol):
+    """Port for reading an OpenAPI document from a source."""
+
+    def load_raw(self) -> Dict[str, Any]:
+        """Load raw OpenAPI content as a dictionary."""
+
+
+class OpenApiValidatorPort(Protocol):
+    """Port for validating and normalizing an OpenAPI document."""
+
+    def validate(self, raw_spec: Dict[str, Any]) -> OpenApiValidationResult:
+        """Validate and normalize OpenAPI content."""
+
+
+class HttpInvokerPort(Protocol):
+    """Port for invoking downstream REST endpoints."""
+
+    async def invoke(self, binding: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Invoke a downstream operation and return normalized response payload."""

--- a/src/openapi_to_mcp/transport/__init__.py
+++ b/src/openapi_to_mcp/transport/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage."""

--- a/src/openapi_to_mcp/transport/app.py
+++ b/src/openapi_to_mcp/transport/app.py
@@ -1,0 +1,84 @@
+"""FastAPI application wiring and runtime bootstrap."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from openapi_to_mcp.adapters.http_invoker import HttpxInvokerAdapter
+from openapi_to_mcp.adapters.openapi_source import FileOpenApiSourceAdapter, UrlOpenApiSourceAdapter
+from openapi_to_mcp.adapters.openapi_validator import OpenApiValidatorAdapter
+from openapi_to_mcp.application.mapper import OperationMapper
+from openapi_to_mcp.application.startup import StartupOrchestrator
+from openapi_to_mcp.application.tool_generator import ToolGenerationService
+from openapi_to_mcp.config import Settings
+from openapi_to_mcp.errors import InvocationError
+from openapi_to_mcp.ports import HttpInvokerPort, OpenApiSourcePort
+from openapi_to_mcp.transport.fastmcp_adapter import FastMcpAdapter
+
+
+class FallbackToolCallRequest(BaseModel):
+    """Compatibility request model for local fallback MCP endpoint."""
+
+    tool: str = Field(min_length=1)
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+def create_app(
+    settings: Settings,
+    source_override: Optional[OpenApiSourcePort] = None,
+    invoker_override: Optional[HttpInvokerPort] = None,
+) -> FastAPI:
+    """Create and configure the FastAPI application."""
+
+    source = source_override or _build_openapi_source(settings)
+    invoker = invoker_override or HttpxInvokerAdapter()
+    mcp_adapter = FastMcpAdapter(invoker=invoker)
+    validator = OpenApiValidatorAdapter()
+    mapper = OperationMapper()
+    generator = ToolGenerationService()
+
+    orchestrator = StartupOrchestrator(
+        source=source,
+        validator=validator,
+        mapper=mapper,
+        generator=generator,
+        mcp_adapter=mcp_adapter,
+    )
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        report = orchestrator.bootstrap()
+        app.state.generation_report = report
+        app.state.mcp_adapter = mcp_adapter
+        app.state.mcp_native = mcp_adapter.supports_streamable_http
+        yield
+
+    app = FastAPI(title="openapi-to-mcp", version="0.1.0", lifespan=lifespan)
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    if mcp_adapter.supports_streamable_http:
+        app.mount("/mcp", mcp_adapter.streamable_http_app())
+    else:
+
+        @app.post("/mcp")
+        async def fallback_mcp_endpoint(request: FallbackToolCallRequest) -> Any:
+            try:
+                return await mcp_adapter.invoke_fallback(request.tool, request.arguments)
+            except InvocationError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return app
+
+
+def _build_openapi_source(settings: Settings) -> OpenApiSourcePort:
+    source_type, source_value = settings.resolve_openapi_source()
+    if source_type == "path":
+        return FileOpenApiSourceAdapter(source_value)
+    return UrlOpenApiSourceAdapter(source_value)

--- a/src/openapi_to_mcp/transport/fastmcp_adapter.py
+++ b/src/openapi_to_mcp/transport/fastmcp_adapter.py
@@ -1,0 +1,79 @@
+"""FastMCP transport adapter with local fallback when package is unavailable."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, Dict
+
+from openapi_to_mcp.domain.models import GeneratedTool
+from openapi_to_mcp.errors import InvocationError, ToolRegistrationError
+from openapi_to_mcp.ports import HttpInvokerPort
+
+try:
+    from mcp.server.fastmcp import FastMCP  # type: ignore
+except Exception:  # pragma: no cover - environment dependent
+    FastMCP = None  # type: ignore
+
+
+class _LocalMcpServer:
+    """Very small fallback MCP-like runtime for environments without FastMCP."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._tools: Dict[str, Callable[..., Any]] = {}
+
+    def tool(self, name: str | None = None, description: str | None = None) -> Callable[..., Any]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            tool_name = name or func.__name__
+            self._tools[tool_name] = func
+            return func
+
+        return decorator
+
+    async def invoke(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
+        func = self._tools.get(tool_name)
+        if func is None:
+            raise InvocationError(f"Tool not found: {tool_name}")
+
+        result = func(**arguments)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+
+class FastMcpAdapter:
+    """Adapter that registers generated tools into FastMCP or local fallback."""
+
+    def __init__(self, invoker: HttpInvokerPort, server_name: str = "openapi-to-mcp") -> None:
+        self._invoker = invoker
+        self._server_name = server_name
+        self._native = FastMCP is not None
+        self._runtime = FastMCP(server_name) if self._native else _LocalMcpServer(server_name)
+
+    @property
+    def supports_streamable_http(self) -> bool:
+        return self._native and hasattr(self._runtime, "streamable_http_app")
+
+    def streamable_http_app(self) -> Any:
+        if not self.supports_streamable_http:
+            raise ToolRegistrationError("FastMCP streamable HTTP app is not available.")
+        return self._runtime.streamable_http_app()  # type: ignore[no-any-return]
+
+    def register_tools(self, tools: list[GeneratedTool]) -> None:
+        for tool in tools:
+            self._register_single_tool(tool)
+
+    async def invoke_fallback(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
+        if self._native:
+            raise InvocationError("Fallback invoke is only available in local MCP mode.")
+        return await self._runtime.invoke(tool_name, arguments)
+
+    def _register_single_tool(self, tool: GeneratedTool) -> None:
+        async def dynamic_tool(**kwargs: Any) -> Dict[str, Any]:
+            return await self._invoker.invoke(tool.binding, kwargs)
+
+        try:
+            decorator = self._runtime.tool(name=tool.name, description=tool.description)
+            decorator(dynamic_tool)
+        except Exception as exc:  # pragma: no cover - defensive against runtime API changes
+            raise ToolRegistrationError(f"Cannot register tool: {tool.name}") from exc

--- a/tests/fixtures/invalid-openapi.yaml
+++ b/tests/fixtures/invalid-openapi.yaml
@@ -1,0 +1,4 @@
+openapi: 3.1.0
+info:
+  title: Invalid API
+  version: 1.0.0

--- a/tests/fixtures/sample-openapi.yaml
+++ b/tests/fixtures/sample-openapi.yaml
@@ -1,0 +1,40 @@
+openapi: 3.1.0
+info:
+  title: Sample API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /pets/{petId}:
+    parameters:
+      - name: petId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPet
+      summary: Get pet by id
+      parameters:
+        - name: includeHistory
+          in: query
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: ok
+    post:
+      summary: Update pet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nickname:
+                  type: string
+      responses:
+        '200':
+          description: ok

--- a/tests/integration/test_app_smoke.py
+++ b/tests/integration/test_app_smoke.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from openapi_to_mcp.config import Settings
+from openapi_to_mcp.transport.app import create_app
+
+
+class StubInvoker:
+    async def invoke(self, binding, payload):
+        return {"ok": True, "binding": binding, "payload": payload}
+
+
+def test_app_healthz_and_fallback_mcp(tmp_path: Path) -> None:
+    spec_file = tmp_path / "openapi.yaml"
+    spec_file.write_text(
+        """
+openapi: 3.1.0
+info:
+  title: Demo
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
+""".strip(),
+        encoding="utf-8",
+    )
+
+    settings = Settings.from_env({"OPENAPI_SPEC_PATH": str(spec_file)})
+    app = create_app(settings, invoker_override=StubInvoker())
+
+    with TestClient(app) as client:
+        health = client.get("/healthz")
+        assert health.status_code == 200
+        assert health.json() == {"status": "ok"}
+
+        if not app.state.mcp_native:
+            response = client.post("/mcp", json={"tool": "getPet", "arguments": {"petId": "123"}})
+            assert response.status_code == 200
+            body = response.json()
+            assert body["ok"] is True
+            assert body["payload"]["petId"] == "123"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from openapi_to_mcp.config import Settings
+from openapi_to_mcp.errors import ConfigurationError
+
+
+def test_settings_requires_openapi_source() -> None:
+    with pytest.raises(ConfigurationError):
+        Settings.from_env({})
+
+
+def test_settings_defaults_and_path_precedence() -> None:
+    settings = Settings.from_env(
+        {
+            "OPENAPI_SPEC_PATH": "./spec.yaml",
+            "OPENAPI_SPEC_URL": "https://example.com/openapi.yaml",
+        }
+    )
+
+    assert settings.mcp_host == "0.0.0.0"
+    assert settings.mcp_port == 8080
+    assert settings.log_level == "info"
+    assert settings.resolve_openapi_source() == ("path", "./spec.yaml")
+
+
+def test_settings_invalid_port() -> None:
+    with pytest.raises(ConfigurationError):
+        Settings.from_env({"OPENAPI_SPEC_PATH": "./spec.yaml", "MCP_PORT": "abc"})

--- a/tests/unit/test_fastmcp_adapter.py
+++ b/tests/unit/test_fastmcp_adapter.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mcp.server.fastmcp")
+
+from openapi_to_mcp.domain.models import GeneratedTool
+from openapi_to_mcp.transport.fastmcp_adapter import FastMcpAdapter
+
+
+class StubInvoker:
+    async def invoke(self, binding, payload):
+        return {"ok": True, "binding": binding, "payload": payload}
+
+
+def test_fastmcp_adapter_native_streamable_app() -> None:
+    adapter = FastMcpAdapter(invoker=StubInvoker())
+
+    if not adapter.supports_streamable_http:
+        pytest.skip("FastMCP streamable HTTP transport not available in this environment")
+
+    tool = GeneratedTool(
+        name="getPet",
+        description="Get a pet",
+        input_schema={"type": "object"},
+        binding={"method": "get", "path": "/pets/{petId}", "server_url": "https://api.example.com"},
+    )
+
+    adapter.register_tools([tool])
+    app = adapter.streamable_http_app()
+
+    assert app is not None
+    assert callable(app)

--- a/tests/unit/test_mapper.py
+++ b/tests/unit/test_mapper.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from openapi_to_mcp.application.mapper import OperationMapper
+
+
+def test_operation_mapper_maps_operations_and_parameters() -> None:
+    spec = {
+        "openapi": "3.1.0",
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/pets/{petId}": {
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "get": {
+                    "operationId": "getPet",
+                    "parameters": [
+                        {
+                            "name": "includeHistory",
+                            "in": "query",
+                            "required": False,
+                            "schema": {"type": "boolean"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            }
+        },
+    }
+
+    operations = OperationMapper().map_operations(spec)
+
+    assert len(operations) == 1
+    op = operations[0]
+    assert op.operation_id == "getPet"
+    assert op.server_url == "https://api.example.com"
+    names = {f"{p['in']}:{p['name']}" for p in op.parameters}
+    assert names == {"path:petId", "query:includeHistory"}
+
+
+def test_operation_mapper_uses_server_override_precedence() -> None:
+    spec = {
+        "openapi": "3.1.0",
+        "servers": [{"url": "https://root.example.com"}],
+        "paths": {
+            "/root-only": {
+                "get": {
+                    "operationId": "rootOnly",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+            "/path-level": {
+                "servers": [{"url": "https://path.example.com"}],
+                "get": {
+                    "operationId": "pathLevel",
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+            "/operation-level": {
+                "servers": [{"url": "https://path-override.example.com"}],
+                "get": {
+                    "operationId": "operationLevel",
+                    "servers": [{"url": "https://operation.example.com"}],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+
+    operations = OperationMapper().map_operations(spec)
+    by_id = {op.operation_id: op for op in operations}
+
+    assert by_id["rootOnly"].server_url == "https://root.example.com"
+    assert by_id["pathLevel"].server_url == "https://path.example.com"
+    assert by_id["operationLevel"].server_url == "https://operation.example.com"

--- a/tests/unit/test_openapi_source.py
+++ b/tests/unit/test_openapi_source.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openapi_to_mcp.adapters.openapi_source import FileOpenApiSourceAdapter, UrlOpenApiSourceAdapter
+from openapi_to_mcp.errors import SourceLoadError
+
+
+def test_file_source_loads_yaml(tmp_path: Path) -> None:
+    spec_file = tmp_path / "openapi.yaml"
+    spec_file.write_text("openapi: 3.1.0\npaths: {}\n", encoding="utf-8")
+
+    adapter = FileOpenApiSourceAdapter(str(spec_file))
+    loaded = adapter.load_raw()
+
+    assert loaded["openapi"] == "3.1.0"
+
+
+def test_file_source_raises_for_missing_file() -> None:
+    adapter = FileOpenApiSourceAdapter("/tmp/does-not-exist.yaml")
+    with pytest.raises(SourceLoadError):
+        adapter.load_raw()
+
+
+def test_url_source_uses_fetcher() -> None:
+    expected = {"openapi": "3.1.0", "paths": {}}
+
+    def fake_fetcher(url: str):
+        assert url == "https://example.com/openapi.yaml"
+        return expected
+
+    adapter = UrlOpenApiSourceAdapter("https://example.com/openapi.yaml", fetcher=fake_fetcher)
+    loaded = adapter.load_raw()
+
+    assert loaded == expected

--- a/tests/unit/test_openapi_validator.py
+++ b/tests/unit/test_openapi_validator.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from openapi_to_mcp.adapters.openapi_validator import OpenApiValidatorAdapter
+from openapi_to_mcp.errors import OpenApiValidationError
+
+
+def test_validator_accepts_minimal_valid_spec() -> None:
+    validator = OpenApiValidatorAdapter()
+    result = validator.validate(
+        {
+            "openapi": "3.1.0",
+            "servers": [{"url": "https://api.example.com"}],
+            "paths": {
+                "/pets": {
+                    "get": {
+                        "operationId": "listPets",
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        }
+    )
+
+    assert result.spec["openapi"] == "3.1.0"
+    assert result.warnings == []
+
+
+def test_validator_warns_on_missing_operation_id() -> None:
+    validator = OpenApiValidatorAdapter()
+    result = validator.validate(
+        {
+            "openapi": "3.1.0",
+            "servers": [{"url": "https://api.example.com"}],
+            "paths": {"/pets": {"get": {"responses": {"200": {"description": "ok"}}}}},
+        }
+    )
+
+    assert len(result.warnings) == 1
+
+
+def test_validator_rejects_missing_paths() -> None:
+    validator = OpenApiValidatorAdapter()
+    with pytest.raises(OpenApiValidationError):
+        validator.validate({"openapi": "3.1.0"})
+
+
+def test_validator_rejects_operation_without_resolvable_server_url() -> None:
+    validator = OpenApiValidatorAdapter()
+    with pytest.raises(OpenApiValidationError):
+        validator.validate(
+            {
+                "openapi": "3.1.0",
+                "paths": {
+                    "/pets": {
+                        "get": {
+                            "operationId": "listPets",
+                            "responses": {"200": {"description": "ok"}},
+                        }
+                    }
+                },
+            }
+        )
+
+
+def test_validator_accepts_operation_level_server_override() -> None:
+    validator = OpenApiValidatorAdapter()
+    result = validator.validate(
+        {
+            "openapi": "3.1.0",
+            "paths": {
+                "/pets": {
+                    "get": {
+                        "operationId": "listPets",
+                        "servers": [{"url": "https://op.example.com"}],
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        }
+    )
+
+    assert result.spec["openapi"] == "3.1.0"

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from openapi_to_mcp.application.mapper import OperationMapper
+from openapi_to_mcp.application.startup import StartupOrchestrator
+from openapi_to_mcp.application.tool_generator import ToolGenerationService
+from openapi_to_mcp.ports import OpenApiValidationResult
+
+
+class StubSource:
+    def load_raw(self):
+        return {
+            "openapi": "3.1.0",
+            "servers": [{"url": "https://api.example.com"}],
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        }
+
+
+class StubValidator:
+    def validate(self, raw_spec):
+        return OpenApiValidationResult(spec=raw_spec, warnings=["sample warning"])
+
+
+class StubMcpAdapter:
+    def __init__(self):
+        self.registered_tools = []
+
+    def register_tools(self, tools):
+        self.registered_tools.extend(tools)
+
+
+def test_startup_orchestrator_bootstraps_and_registers_tools() -> None:
+    mcp = StubMcpAdapter()
+    orchestrator = StartupOrchestrator(
+        source=StubSource(),
+        validator=StubValidator(),
+        mapper=OperationMapper(),
+        generator=ToolGenerationService(),
+        mcp_adapter=mcp,
+    )
+
+    report = orchestrator.bootstrap()
+
+    assert report.generated_count == 1
+    assert len(mcp.registered_tools) == 1
+    assert report.warnings == ["sample warning"]

--- a/tests/unit/test_tool_generator.py
+++ b/tests/unit/test_tool_generator.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from openapi_to_mcp.application.tool_generator import ToolGenerationService
+from openapi_to_mcp.domain.models import ApiOperation
+
+
+def test_generator_uses_operation_id_when_present() -> None:
+    operation = ApiOperation(
+        method="get",
+        path="/pets/{petId}",
+        operation_id="getPet",
+        summary="Get pet",
+        parameters=[],
+        request_body_schema=None,
+        request_body_required=False,
+        server_url="https://api.example.com",
+    )
+
+    tools, report = ToolGenerationService().generate([operation])
+
+    assert report.generated_count == 1
+    assert tools[0].name == "getPet"
+
+
+def test_generator_uses_fallback_name_and_input_schema() -> None:
+    operation = ApiOperation(
+        method="post",
+        path="/pets/{petId}",
+        operation_id=None,
+        summary=None,
+        parameters=[
+            {"name": "petId", "in": "path", "required": True, "schema": {"type": "string"}},
+            {
+                "name": "includeHistory",
+                "in": "query",
+                "required": False,
+                "schema": {"type": "boolean"},
+            },
+        ],
+        request_body_schema={"type": "object"},
+        request_body_required=True,
+        server_url="https://api.example.com",
+    )
+
+    tools, _ = ToolGenerationService().generate([operation])
+    tool = tools[0]
+
+    assert tool.name == "post_pets_by_petId"
+    assert tool.input_schema["required"] == ["body", "petId"]
+    assert tool.binding["path_params"] == ["petId"]
+    assert tool.binding["query_params"] == ["includeHistory"]


### PR DESCRIPTION
## Summary
- Parent issue: #1
- Sub-issues: #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13
- Change type: feat

Applicability rule:
- For `feat`/`fix`, lifecycle, architecture, and TDD requirements are mandatory.
- For non-`feat`/`fix` PRs, complete only applicable items and use `N/A - <reason>` for out-of-scope fields.
- If PR scope is mixed, apply the strictest relevant requirements.

## Mandatory Links (Scope-Conditional)
- Functional analysis issue (Required for `feat`/`fix`): #1
- Operational plan comment (Required for `feat`/`fix`, issue permalink): https://github.com/Albe83/openapi-to-mcp/issues/1#issuecomment-3938841028
- ADR(s) (Required for `feat`/`fix`): `docs/adr/0001-python-fastapi-fastmcp-bootstrap.md`
- Class diagram file (Required for `feat`/`fix`): `docs/diagrams/0002-class-bootstrap-core.md`
- Sequence diagram file (Required for `feat`/`fix`): `docs/diagrams/0003-sequence-startup-and-tool-call.md`
- Data model schema location(s) (Required if model changed): `docs/schemas/0001-core-domain-models.schema.yaml`
- Hexagonal applicable for this change? `yes`
- Hexagonal ADR mapping location (Required if applicable): `docs/adr/0001-python-fastapi-fastmcp-bootstrap.md` (Decision)
- Hexagonal diagram file (Required if applicable): `docs/diagrams/0004-hexagonal-bootstrap-boundaries.md`
- If not applicable: `N/A - Hexagonal not applicable: <reason>`
- Public API change? `yes`
- IDL type (Required if API changed): `OpenAPI`
- IDL spec location (Required if API changed): `docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml`
- DDD artifacts location(s) (Required if model/schema changed): `docs/adr/0001-python-fastapi-fastmcp-bootstrap.md` (DDD Assessment)

## TDD Evidence (Required for `feat`/`fix`)
If change type is not `feat`/`fix`, set this section to `N/A - <reason>`.

### Feature
- [x] Test-first sequence documented.
- [x] New/updated tests were written before implementation.

### Bugfix
- [x] Reproduction test added first.
- [x] Reproduction test failed before fix.
- [x] Reproduction + regression tests pass after fix.

## Validation
- [x] Test commands run (or `N/A - <reason>`):
  - `make test`
- [x] Task-start branch guard evidence:
  - `git branch --show-current`
  - `git fetch origin`
  - `git merge --ff-only origin/main` (or equivalent)
- [x] Lint commands run for changed artifacts with available linter:
  - `make lint`
- [x] `N/A` with reason for changed artifacts without linter (if any):
  - `N/A - all changed code artifacts have lint/test coverage`
- [x] Results summary:
  - `18 passed` tests
  - `ruff check` passed

## Review Findings (Mandatory)
- Author self-review completed: `yes`
- Independent review completed: `yes`
- Findings outcome: `findings listed`
- If outcome is `no findings`, include exact statement: `no findings`
- If outcome is `findings listed`, fill one table row per finding.

| Finding | Category | Priority | Sub-issue |
| --- | --- | --- | --- |
| Missing server URL resolution could create runtime-dead tools (resolved in this PR) | Bug | High | #12 |
| Mapper ignored operation/path server override precedence (resolved in this PR) | Bug | High | #13 |

## Impact and Risk
- Scope of impact: introduces full bootstrap runtime for OpenAPI -> MCP tool generation.
- Compatibility notes: no backward compatibility break; first implementation baseline.
- Rollout notes: deploy artifacts intentionally out of scope for this increment.

## Checklist
- [x] PR targets `main`.
- [x] Branch follows `type/issue-id-slug`.
- [x] Conventional Commits used.
- [x] Task started on the correct branch and branch was synced with base before implementation.
- [x] For `feat`/`fix`, required lifecycle links are present (analysis issue + plan comment + sub-issues).
- [x] For `feat`/`fix`, class and sequence diagrams are in Markdown Mermaid and render in GitHub.
- [x] For `feat`/`fix`, diagram files are in `docs/diagrams/*.md` and linked in ADR and PR.
- [x] For `feat`/`fix` boundary/integration changes, Hexagonal applicability is assessed.
- [x] If Hexagonal is applicable, ADR mapping + dedicated Hexagonal diagram are linked.
- [x] If Hexagonal is not applicable, explicit `N/A` rationale is provided.
- [x] If data model changed, JSON Schema is updated in [docs/schemas/](../docs/schemas) (YAML preferred).
- [x] If public API changed, formal IDL is updated in [docs/interfaces/](../docs/interfaces) and linked.
- [x] If IDL format supports YAML, YAML is preferred (JSON only if needed).
- [x] If data model/schema changed, DDD applicability is assessed.
- [x] If DDD is applicable, UL/BC/Aggregates are documented and linked.
- [x] New/updated ADR/docs/comments are written in simple English.
- [x] Any non-simple wording is justified when required for precision.
- [x] Mandatory review completed (author + independent reviewer).
- [x] Review outcome is explicit (`no findings` or findings listed in table).
- [x] If findings exist, one sub-issue exists for each finding.
- [x] Task/finding sub-issues use `task` + exactly one `basic`/`advanced` label.
- [x] `advanced` sub-issues include rationale for non-decomposable complexity.
- [x] Finding priorities use policy mapping (Bug/Security=High, Optimization/Code Quality=Medium, other=Low).
- [x] Lint executed for changed artifacts where available; missing linter coverage documented as `N/A` with reason.
- [x] Related docs updated.
- [x] SemVer impact evaluated (if release-related).
