### PR TITLE
feat: optional Prometheus-compatible metrics toggle (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository now includes a working Python technical foundation:
 - Operation mapping and MCP tool generation (`operationId` first, deterministic fallback).
 - Health endpoint (`GET /healthz`).
 - OTLP telemetry export with OpenTelemetry SDK instrumentation.
+- Optional Prometheus-compatible metrics endpoint (`GET /metrics`) behind feature toggle.
 - Local fallback MCP endpoint (`POST /mcp`) when FastMCP is not available.
 
 Architecture and governance artifacts:
@@ -39,6 +40,7 @@ Optional:
 - `TELEMETRY_OTLP_PROTOCOL` (`grpc` default, `http` fallback)
 - `TELEMETRY_OTLP_ENDPOINT` (default `http://127.0.0.1:4317` for `grpc`)
 - `TELEMETRY_EXPORT_INTERVAL_MS` (default `60000`)
+- `PROMETHEUS_METRICS_ENABLED` (`false` default; when `true`, enables `GET /metrics`)
 - `SERVICE_NAME` (default `openapi-to-mcp`)
 - `SERVICE_NAMESPACE` (default `openapi-to-mcp`)
 - `DEPLOYMENT_ENVIRONMENT` (default `dev`)
@@ -168,6 +170,7 @@ Event-Driven and Pub/Sub governance rules are defined in [docs/policies/19-m2m-e
 ## Metrics and Telemetry Transport Policy
 Telemetry export and transport rules are defined in [docs/policies/22-metrics-transport-standard.md](docs/policies/22-metrics-transport-standard.md).
 Current runtime exports metrics via OTLP to a Collector target configured through environment variables.
+Prometheus-compatible scraping is optional and disabled by default (`PROMETHEUS_METRICS_ENABLED=false`).
 
 ## Metrics Design Policy
 Metrics semantic design rules (naming, units, USE, RED, and latency histograms) are defined in [docs/policies/23-metrics-design-use-red.md](docs/policies/23-metrics-design-use-red.md).

--- a/docs/adr/0004-otlp-telemetry-red-use-and-metrics-deprecation.md
+++ b/docs/adr/0004-otlp-telemetry-red-use-and-metrics-deprecation.md
@@ -1,6 +1,6 @@
 # ADR 0004: OTLP Telemetry with RED and USE Metrics (Remove `/metrics`)
 
-- Status: Accepted
+- Status: Superseded by [ADR 0005](0005-optional-prometheus-compatibility-toggle.md)
 - Date: 2026-02-22
 - Parent issue: #TBD
 - Related sub-issues: #TBD

--- a/docs/adr/0005-optional-prometheus-compatibility-toggle.md
+++ b/docs/adr/0005-optional-prometheus-compatibility-toggle.md
@@ -1,0 +1,58 @@
+# ADR 0005: Optional Prometheus Compatibility Metrics Endpoint
+
+- Status: Accepted
+- Date: 2026-02-23
+- Parent issue: #59
+- Related sub-issues: #60, #61, #62, #63, #64, #65, #66
+
+## Context
+Policy `22` requires OpenTelemetry instrumentation and OTLP export as the default telemetry transport.
+Policy `23` requires stable USE and RED semantics for metrics.
+
+ADR 0004 removed `/metrics` to simplify runtime telemetry to a single OTLP path.
+A compatibility need now exists for environments that still rely on Prometheus scrape workflows.
+
+The required behavior is:
+- Prometheus compatibility available when explicitly enabled.
+- Disabled by default.
+- No behavior change for current default runtime.
+
+## Decision
+Introduce an optional Prometheus-compatible metrics feature toggle.
+
+### Toggle
+- New runtime setting: `PROMETHEUS_METRICS_ENABLED`.
+- Default: `false`.
+- When `false`, `GET /metrics` is not mounted and returns `404`.
+- When `true`, `GET /metrics` returns Prometheus-compatible exposition.
+
+### Telemetry Architecture
+- Keep OpenTelemetry SDK instrumentation as the single metrics instrumentation source.
+- Keep OTLP export to Collector enabled as default path.
+- Add Prometheus-compatible reader/exposition only when toggle is enabled.
+- Do not change existing metric names, units, RED/USE model, or histogram boundaries.
+
+## DDD and Hexagonal Assessment
+- DDD: not applicable. No domain model changes.
+- Hexagonal: applicable only at infrastructure observability adapter level; domain and application boundaries are unchanged.
+
+## Alternatives Considered
+1. Keep OTLP-only and reject Prometheus compatibility.
+   - Rejected: does not meet compatibility need.
+2. Reintroduce `/metrics` always enabled.
+   - Rejected: changes default behavior and increases operational surface for all environments.
+3. Introduce separate metrics sidecar/service.
+   - Rejected: adds deployment complexity for this scope.
+
+## Consequences
+- Positive: preserves current OTLP-first architecture.
+- Positive: supports Prometheus scraping where needed.
+- Positive: default behavior remains unchanged.
+- Negative: optional path increases observability runtime complexity.
+- Mitigation: strict toggle default off and explicit tests for both modes.
+
+## Required Artifact Links
+- Class diagram: [docs/diagrams/0011-class-optional-prometheus-telemetry.md](../diagrams/0011-class-optional-prometheus-telemetry.md)
+- Sequence diagram: [docs/diagrams/0012-sequence-conditional-metrics-scrape.md](../diagrams/0012-sequence-conditional-metrics-scrape.md)
+- Public API IDL: [docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml](../interfaces/0001-openapi-to-mcp-server-openapi.yaml)
+- Previous decision reference: [docs/adr/0004-otlp-telemetry-red-use-and-metrics-deprecation.md](0004-otlp-telemetry-red-use-and-metrics-deprecation.md)

--- a/docs/diagrams/0011-class-optional-prometheus-telemetry.md
+++ b/docs/diagrams/0011-class-optional-prometheus-telemetry.md
@@ -1,0 +1,43 @@
+# Class Diagram: Optional Prometheus Compatibility Telemetry
+
+Purpose: Describe runtime components and dependencies for OTLP default telemetry plus optional Prometheus-compatible exposition.
+Parent issue: #59
+ADR reference: [docs/adr/0005-optional-prometheus-compatibility-toggle.md](../adr/0005-optional-prometheus-compatibility-toggle.md)
+
+```mermaid
+classDiagram
+    class Settings {
+        +bool prometheus_metrics_enabled
+        +str telemetry_otlp_protocol
+        +str telemetry_otlp_endpoint
+    }
+
+    class RuntimeMetrics {
+        -MeterProvider _meter_provider
+        -bool _prometheus_enabled
+        +on_http_request_completed(route, method, status_code, duration)
+        +render_prometheus_payload() bytes
+        +prometheus_content_type() str
+        +shutdown() None
+    }
+
+    class TelemetryRuntime {
+        +MeterProvider provider
+        +Meter meter
+    }
+
+    class TelemetryBuilder {
+        +build_telemetry_runtime(..., enable_prometheus) TelemetryRuntime
+    }
+
+    class FastAPIApp {
+        +GET /healthz
+        +GET /metrics (conditional)
+        +POST /mcp
+    }
+
+    Settings --> RuntimeMetrics : configures
+    RuntimeMetrics --> TelemetryBuilder : calls
+    TelemetryBuilder --> TelemetryRuntime : creates
+    FastAPIApp --> RuntimeMetrics : uses for RED/USE + scrape
+```

--- a/docs/diagrams/0012-sequence-conditional-metrics-scrape.md
+++ b/docs/diagrams/0012-sequence-conditional-metrics-scrape.md
@@ -1,0 +1,35 @@
+# Sequence Diagram: Conditional Metrics Scrape Flow
+
+Purpose: Show request behavior for `/metrics` when Prometheus compatibility is enabled or disabled.
+Parent issue: #59
+ADR reference: [docs/adr/0005-optional-prometheus-compatibility-toggle.md](../adr/0005-optional-prometheus-compatibility-toggle.md)
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FastAPI
+    participant Settings
+    participant RuntimeMetrics
+    participant OTelProvider
+
+    Note over FastAPI,Settings: Startup
+    FastAPI->>Settings: read PROMETHEUS_METRICS_ENABLED
+    FastAPI->>RuntimeMetrics: initialize(enable_prometheus)
+    RuntimeMetrics->>OTelProvider: configure OTLP reader (always)
+    alt enable_prometheus = true
+        RuntimeMetrics->>OTelProvider: add Prometheus-compatible reader
+        FastAPI->>FastAPI: register GET /metrics
+    else enable_prometheus = false
+        FastAPI->>FastAPI: do not register /metrics
+    end
+
+    Note over Client,FastAPI: Runtime scrape request
+    Client->>FastAPI: GET /metrics
+    alt endpoint enabled
+        FastAPI->>RuntimeMetrics: render_prometheus_payload()
+        RuntimeMetrics-->>FastAPI: metrics text + content type
+        FastAPI-->>Client: 200 Prometheus-compatible payload
+    else endpoint disabled
+        FastAPI-->>Client: 404 Not Found
+    end
+```

--- a/docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml
+++ b/docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml
@@ -26,6 +26,22 @@ paths:
                   status:
                     type: string
                     enum: [ok]
+  /metrics:
+    get:
+      summary: Prometheus-compatible metrics scrape endpoint
+      operationId: getMetrics
+      description: |
+        Optional endpoint enabled only when `PROMETHEUS_METRICS_ENABLED=true`.
+        If disabled, route is not mounted and returns 404.
+      responses:
+        '200':
+          description: Prometheus-compatible metrics payload
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Metrics feature disabled
   /mcp:
     post:
       summary: Streamable HTTP entrypoint for MCP messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,10 @@ dependencies = [
   "opentelemetry-api>=1.27.0",
   "opentelemetry-exporter-otlp-proto-grpc>=1.27.0",
   "opentelemetry-exporter-otlp-proto-http>=1.27.0",
+  "opentelemetry-exporter-prometheus>=0.48b0",
   "opentelemetry-sdk>=1.27.0",
   "pydantic>=2.8.0",
+  "prometheus-client>=0.20.0",
   "pyyaml>=6.0.0",
   "uvicorn>=0.30.0",
 ]

--- a/tests/integration/test_app_smoke.py
+++ b/tests/integration/test_app_smoke.py
@@ -59,3 +59,48 @@ paths:
             body = response.json()
             assert body["ok"] is True
             assert body["payload"]["petId"] == "123"
+
+
+def test_app_exposes_metrics_only_when_prometheus_toggle_enabled(tmp_path: Path) -> None:
+    spec_file = tmp_path / "openapi.yaml"
+    spec_file.write_text(
+        """
+openapi: 3.1.0
+info:
+  title: Demo
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
+""".strip(),
+        encoding="utf-8",
+    )
+
+    settings = Settings.from_env(
+        {
+            "OPENAPI_SPEC_PATH": str(spec_file),
+            "PROMETHEUS_METRICS_ENABLED": "true",
+        }
+    )
+    app = create_app(settings, invoker_override=StubInvoker())
+
+    with TestClient(app) as client:
+        health = client.get("/healthz")
+        assert health.status_code == 200
+
+        metrics = client.get("/metrics")
+        assert metrics.status_code == 200
+        assert "text/plain" in metrics.headers["content-type"]
+        assert "openapi_to_mcp_http_server_requests" in metrics.text

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,6 +28,7 @@ def test_settings_defaults_and_path_precedence() -> None:
     assert settings.telemetry_otlp_protocol == "grpc"
     assert settings.telemetry_otlp_endpoint == "http://127.0.0.1:4317"
     assert settings.telemetry_export_interval_ms == 60000
+    assert settings.prometheus_metrics_enabled is False
     assert settings.service_name == "openapi-to-mcp"
     assert settings.service_namespace == "openapi-to-mcp"
     assert settings.deployment_environment == "dev"
@@ -76,5 +77,33 @@ def test_settings_invalid_telemetry_interval() -> None:
             {
                 "OPENAPI_SPEC_PATH": "./spec.yaml",
                 "TELEMETRY_EXPORT_INTERVAL_MS": "0",
+            }
+        )
+
+
+def test_settings_prometheus_toggle_parsing() -> None:
+    settings_enabled = Settings.from_env(
+        {
+            "OPENAPI_SPEC_PATH": "./spec.yaml",
+            "PROMETHEUS_METRICS_ENABLED": "true",
+        }
+    )
+    settings_disabled = Settings.from_env(
+        {
+            "OPENAPI_SPEC_PATH": "./spec.yaml",
+            "PROMETHEUS_METRICS_ENABLED": "false",
+        }
+    )
+
+    assert settings_enabled.prometheus_metrics_enabled is True
+    assert settings_disabled.prometheus_metrics_enabled is False
+
+
+def test_settings_invalid_prometheus_toggle_value() -> None:
+    with pytest.raises(ConfigurationError):
+        Settings.from_env(
+            {
+                "OPENAPI_SPEC_PATH": "./spec.yaml",
+                "PROMETHEUS_METRICS_ENABLED": "maybe",
             }
         )

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -34,3 +34,26 @@ def test_runtime_metrics_records_red_http_metrics_without_exception() -> None:
         duration_seconds=0.018,
     )
     metrics.shutdown()
+
+
+def test_runtime_metrics_prometheus_payload_disabled_by_default() -> None:
+    metrics = RuntimeMetrics(max_in_flight=2, max_connections=4)
+    assert metrics.render_prometheus_payload() is None
+    assert metrics.prometheus_content_type() is None
+    metrics.shutdown()
+
+
+def test_runtime_metrics_renders_prometheus_payload_when_enabled() -> None:
+    metrics = RuntimeMetrics(max_in_flight=2, max_connections=4, prometheus_metrics_enabled=True)
+    metrics.on_http_request_completed(
+        route="/healthz",
+        method="GET",
+        status_code=200,
+        duration_seconds=0.01,
+    )
+
+    payload = metrics.render_prometheus_payload()
+    assert payload is not None
+    assert b"openapi_to_mcp_http_server_requests" in payload
+    assert metrics.prometheus_content_type() is not None
+    metrics.shutdown()


### PR DESCRIPTION
## Summary
- Parent issue: #59
- Sub-issues: #60, #61, #62, #63, #64, #65, #66
- Change type: feat

Applicability rule:
- For `feat`/`fix`, lifecycle, architecture, and TDD requirements are mandatory.
- For non-`feat`/`fix` PRs, complete only applicable items and use `N/A - <reason>` for out-of-scope fields.
- If PR scope is mixed, apply the strictest relevant requirements.

## Mandatory Links (Scope-Conditional)
- Functional analysis issue (Required for `feat`/`fix`): #59
- Operational plan comment (Required for `feat`/`fix`, issue permalink): https://github.com/Albe83/openapi-to-mcp/issues/59#issuecomment-3945921589
- ADR(s) (Required for `feat`/`fix`): `docs/adr/0005-optional-prometheus-compatibility-toggle.md`
- Class diagram file (Required for `feat`/`fix`): `docs/diagrams/0011-class-optional-prometheus-telemetry.md`
- Sequence diagram file (Required for `feat`/`fix`): `docs/diagrams/0012-sequence-conditional-metrics-scrape.md`
- Data model schema location(s) (Required if model changed): `N/A - data model unchanged`
- Hexagonal applicable for this change? `no`
- Hexagonal ADR mapping location (Required if applicable): `N/A - Hexagonal not applicable: domain/application boundaries unchanged`
- Hexagonal diagram file (Required if applicable): `N/A - Hexagonal not applicable: no new boundary/port mapping required`
- If not applicable: `N/A - Hexagonal not applicable: observability change is confined to existing infrastructure path`
- Public API change? `yes`
- IDL type (Required if API changed): `OpenAPI`
- IDL spec location (Required if API changed): `docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml`
- DDD artifacts location(s) (Required if model/schema changed): `N/A - model/schema unchanged`
- Container install/run workflow changed? `no`
- Container policy evidence (Required if `yes`): `N/A - container workflow unchanged`
- Application logging behavior changed? `no`
- Logging policy evidence (Required if `yes`): `N/A - logging behavior unchanged`
- M2M protocol decision changed? `no`
- M2M protocol policy evidence (Required if `yes`): `N/A - protocol decision unchanged`
- Event protocol/contract changed? `no`
- Event messaging policy evidence (Required if `yes`): `N/A - event contracts unchanged`
- Persistence flow changed? `no`
- Persistence policy evidence (Required if `yes`): `N/A - persistence unchanged`
- Broker Pub/Sub integration changed? `no`
- Broker decoupling policy evidence (Required if `yes`): `N/A - broker integration unchanged`
- Telemetry export/transport behavior changed? `yes`
- Telemetry transport policy evidence (Required if `yes`): `src/openapi_to_mcp/telemetry.py`, `src/openapi_to_mcp/metrics.py`, `docs/adr/0005-optional-prometheus-compatibility-toggle.md`
- Metric semantic design changed? `no`
- Metrics design policy evidence (Required if `yes`): `N/A - metric names/units/USE-RED model unchanged`

## TDD Evidence (Required for `feat`/`fix`)
### Feature
- [x] Test-first sequence documented.
- [x] New/updated tests were written before implementation.

Feature test-first sequence:
1. Added tests first in:
   - `tests/unit/test_config.py`
   - `tests/unit/test_metrics.py`
   - `tests/integration/test_app_smoke.py`
2. Pre-implementation failing evidence:
   - `command: python3.11 -m pytest -q tests/unit/test_config.py tests/unit/test_metrics.py tests/integration/test_app_smoke.py`
   - `result: fail (6 failed, 10 passed)`
3. Implemented minimal code changes in config/telemetry/metrics/app.
4. Post-implementation success evidence:
   - `command: python3.11 -m pytest -q tests/unit/test_config.py tests/unit/test_metrics.py tests/integration/test_app_smoke.py`
   - `result: pass (16 passed)`

### Bugfix
- [ ] Reproduction test added first.
- [ ] Reproduction test failed before fix.
- [ ] Reproduction + regression tests pass after fix.
- `N/A - feature change, not a bugfix`

## Validation
- Evidence record format (use for each command):
  - `command: <exact command>`
  - `scope: <artifact/path or change scope>`
  - `result: pass/fail + short summary`
- [x] Test commands run (or `N/A - <reason>`):
  - `command: make test`
  - `scope: repository tests`
  - `result: pass (32 passed)`
- [x] Task-start branch guard evidence:
  - `git branch --show-current` -> `main`
  - `git fetch origin`
  - `git merge --ff-only origin/main` -> `Already up to date`
  - `git switch -c feat/59-prometheus-metrics-toggle`
- [x] Lint commands run for changed artifacts with available linter:
  - `command: make lint`
  - `scope: Python source/tests`
  - `result: pass`
  - `command: make governance-check`
  - `scope: policy/markdown/governance artifacts`
  - `result: pass`
- [x] `N/A` with reason for changed artifacts without linter (if any):
  - `N/A - no additional artifact-specific linter configured`
- [x] AI reasoning-level evidence for labeled tasks/findings (or `N/A - <reason>`):
  - Complexity label used: `basic`
  - Reasoning level selected: `N/A`
  - Support note: `N/A - reasoning level control not supported in this runtime`
- [x] Results summary:
  - `make governance-check`: pass
  - `make lint`: pass
  - `make test`: pass

## Compliance Map (Owner Modules)
Add one row per owner module checked for this PR.
Use `yes`/`no` in `Applies`.
If `Applies=no`, provide `N/A - <reason>`.

| Module | Applies | Evidence Link or Command Result | N/A Reason |
| --- | --- | --- | --- |
| 02 | yes | #59 + plan comment + #60-#66 |  |
| 03 | yes | `docs/adr/0005-optional-prometheus-compatibility-toggle.md`, `docs/diagrams/0011-class-optional-prometheus-telemetry.md`, `docs/diagrams/0012-sequence-conditional-metrics-scrape.md` |  |
| 04 | yes | TDD section + pre/post test evidence + updated tests |  |
| 05 | yes | branch `feat/59-prometheus-metrics-toggle`, Conventional Commit, PR to `main` |  |
| 07 | yes | compliance map + validation evidence + required links |  |
| 10 | yes | review section completed with explicit outcome |  |
| 09 | yes | simple English in ADR/docs/comments |  |
| 11 | yes | `docs/interfaces/0001-openapi-to-mcp-server-openapi.yaml` updated with `/metrics` contract |  |
| 22 | yes | OTLP remains default path in `src/openapi_to_mcp/telemetry.py` and ADR 0005 |  |
| 23 | no |  | N/A - metric semantics unchanged; only optional exposure path added |

## Review Findings (Mandatory)
- Author self-review completed: `yes`
- Independent review completed: `yes`
- Findings outcome: `no findings`
- If outcome is `no findings`, include exact statement: `no findings`
- no findings

| Finding | Category | Priority | Sub-issue |
| --- | --- | --- | --- |

## Impact and Risk
- Scope of impact: telemetry and optional API surface (`/metrics`) only.
- Compatibility notes: default behavior is unchanged (`/metrics` disabled -> 404).
- Rollout notes: enable with `PROMETHEUS_METRICS_ENABLED=true` only in environments that need compatibility scraping.

## Checklist
- [x] PR targets `main`.
- [x] Branch follows `type/issue-id-slug`.
- [x] Conventional Commits used.
- [x] Task started on the correct branch and branch was synced with base before implementation.
- [x] For `feat`/`fix`, required lifecycle links are present (analysis issue + plan comment + sub-issues).
- [x] For `feat`/`fix`, class and sequence diagrams are in Markdown Mermaid and render in GitHub.
- [x] For `feat`/`fix`, diagram files are in `docs/diagrams/*.md` and linked in ADR and PR.
- [x] For `feat`/`fix` boundary/integration changes, Hexagonal applicability is assessed.
- [x] If Hexagonal is not applicable, explicit `N/A` rationale is provided.
- [x] If public API changed, formal IDL is updated in [docs/interfaces/](../docs/interfaces) and linked.
- [x] If IDL format supports YAML, YAML is preferred (JSON only if needed).
- [x] New/updated ADR/docs/comments are written in simple English.
- [x] Lint executed for changed artifacts where available; missing linter coverage documented as `N/A` with reason.
- [x] Related docs updated.
- [x] SemVer impact evaluated (if release-related).
