### PR TITLE
ci: add Xquik fixture coverage and pin Trivy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,9 @@ jobs:
           require_section "## Migration Notes"
           require_section "## References"
 
-          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
-          echo "is_prerelease=${is_prerelease}" >> "${GITHUB_OUTPUT}"
           {
+            echo "tag=${tag}"
+            echo "is_prerelease=${is_prerelease}"
             echo "changelog_body<<EOF"
             printf '%s\n' "${changelog_body}"
             echo "EOF"
@@ -106,9 +106,9 @@ jobs:
           image="ghcr.io/${GITHUB_REPOSITORY,,}"
           package_name="${GITHUB_REPOSITORY#*/}"
           package_name="${package_name,,}"
-          echo "image_ref=${image}:${TAG}" >> "${GITHUB_OUTPUT}"
-          echo "package_name=${package_name}" >> "${GITHUB_OUTPUT}"
           {
+            echo "image_ref=${image}:${TAG}"
+            echo "package_name=${package_name}"
             echo "tags<<EOF"
             echo "${image}:${TAG}"
             if [[ "${IS_PRERELEASE}" == "false" ]]; then
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trivy Scan Published Image
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Trivy Filesystem Scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -97,7 +97,7 @@ jobs:
         run: docker build -f Containerfiles/Containerfile.prod -t openapi-to-mcp:security-scan .
 
       - name: Trivy Image Scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: openapi-to-mcp:security-scan

--- a/tests/fixtures/xquik-openapi.yaml
+++ b/tests/fixtures/xquik-openapi.yaml
@@ -1,0 +1,73 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+  description: >-
+    Xquik is an independent third-party service. Not affiliated with X Corp.
+    "Twitter" and "X" are trademarks of X Corp.
+servers:
+  - url: https://xquik.com
+paths:
+  /api/v1/x/users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: X username without @ or user ID.
+        schema:
+          type: string
+    get:
+      operationId: getUser
+      summary: Get an X user profile with follower counts and verification status.
+      parameters:
+        - name: x-api-key
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User profile.
+  /api/v1/x/tweets/search:
+    get:
+      operationId: searchTweets
+      summary: Search X posts by query with pagination.
+      parameters:
+        - name: x-api-key
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: queryType
+          in: query
+          schema:
+            type: string
+            enum:
+              - Latest
+              - Top
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: sinceTime
+          in: query
+          schema:
+            type: string
+        - name: untilTime
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Search results.

--- a/tests/unit/test_mapper.py
+++ b/tests/unit/test_mapper.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import yaml
+
 from openapi_to_mcp.application.mapper import OperationMapper
+
+FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
 
 
 def test_operation_mapper_maps_operations_and_parameters() -> None:
@@ -78,3 +84,27 @@ def test_operation_mapper_uses_server_override_precedence() -> None:
     assert by_id["rootOnly"].server_url == "https://root.example.com"
     assert by_id["pathLevel"].server_url == "https://path.example.com"
     assert by_id["operationLevel"].server_url == "https://operation.example.com"
+
+
+def test_operation_mapper_maps_xquik_openapi_31_fixture() -> None:
+    spec = yaml.safe_load((FIXTURES_DIR / "xquik-openapi.yaml").read_text())
+
+    operations = OperationMapper().map_operations(spec)
+    by_id = {op.operation_id: op for op in operations}
+
+    assert set(by_id) == {"getUser", "searchTweets"}
+    assert by_id["getUser"].path == "/api/v1/x/users/{id}"
+    assert by_id["getUser"].server_url == "https://xquik.com"
+    assert {(p["in"], p["name"]) for p in by_id["getUser"].parameters} == {
+        ("header", "x-api-key"),
+        ("path", "id"),
+    }
+    assert {(p["in"], p["name"]) for p in by_id["searchTweets"].parameters} == {
+        ("header", "x-api-key"),
+        ("query", "cursor"),
+        ("query", "limit"),
+        ("query", "q"),
+        ("query", "queryType"),
+        ("query", "sinceTime"),
+        ("query", "untilTime"),
+    }

--- a/tests/unit/test_tool_generator.py
+++ b/tests/unit/test_tool_generator.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import yaml
+
+from openapi_to_mcp.application.mapper import OperationMapper
 from openapi_to_mcp.application.tool_generator import ToolGenerationService
 from openapi_to_mcp.domain.models import ApiOperation
+
+FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
 
 
 def test_generator_uses_operation_id_when_present() -> None:
@@ -49,3 +56,26 @@ def test_generator_uses_fallback_name_and_input_schema() -> None:
     assert tool.input_schema["required"] == ["body", "petId"]
     assert tool.binding["path_params"] == ["petId"]
     assert tool.binding["query_params"] == ["includeHistory"]
+
+
+def test_generator_preserves_xquik_auth_path_and_pagination_inputs() -> None:
+    spec = yaml.safe_load((FIXTURES_DIR / "xquik-openapi.yaml").read_text())
+    operations = OperationMapper().map_operations(spec)
+
+    tools, report = ToolGenerationService().generate(operations)
+    by_name = {tool.name: tool for tool in tools}
+
+    assert report.generated_count == 2
+    assert report.skipped_count == 0
+    assert by_name["getUser"].binding["server_url"] == "https://xquik.com"
+    assert by_name["getUser"].binding["path_params"] == ["id"]
+    assert by_name["getUser"].binding["header_params"] == ["x-api-key"]
+    assert by_name["searchTweets"].binding["query_params"] == [
+        "q",
+        "queryType",
+        "cursor",
+        "sinceTime",
+        "untilTime",
+        "limit",
+    ]
+    assert by_name["searchTweets"].input_schema["required"] == ["q", "x-api-key"]


### PR DESCRIPTION
## Summary
- Parent issue: N/A - this is test and CI maintenance, not a feat or fix.
- Sub-issues: N/A - no task decomposition is required for this small change.
- Change type: ci
- Add reusable Xquik OpenAPI 3.1 fixture coverage for mapping and tool generation.
- Use the canonical `x-api-key` REST header and include the Xquik independence notice.
- Pin every Trivy workflow use to the verified commit behind `v0.36.0`.
- Group release outputs so the touched workflows pass actionlint and shellcheck.

## Independent Repository Fix
The security and release workflows used `aquasecurity/trivy-action@master` in 3 places. A mutable ref can execute different third-party code without any repository change. This PR pins all 3 uses to immutable commit [`ed142fd0673e97e23eac54620cfb913e5ce36c25`](https://github.com/aquasecurity/trivy-action/commit/ed142fd0673e97e23eac54620cfb913e5ce36c25), which is the commit behind the signed `v0.36.0` release tag.

## Mandatory Links
- Functional analysis issue: N/A - not a feat or fix change.
- Operational plan comment: N/A - not a feat or fix change.
- ADRs: N/A - no architecture decision changed.
- Class diagram file: N/A - no architecture diagram changed.
- Sequence diagram file: N/A - no architecture diagram changed.
- Data model schema locations: N/A - no domain model changed.
- Hexagonal applicable for this change? no
- Hexagonal ADR mapping location: N/A - no boundary or adapter changed.
- Public API change? no
- IDL type: N/A - no project public API changed.
- IDL spec location: N/A - no project public API changed.
- DDD artifacts locations: N/A - no model or schema changed.
- Container install or run workflow changed? no
- Container policy evidence: N/A - no container workflow changed.
- Application logging behavior changed? no
- Logging policy evidence: N/A - no logging behavior changed.
- M2M protocol decision changed? no
- M2M protocol policy evidence: N/A - no protocol decision changed.
- Event protocol or contract changed? no
- Event messaging policy evidence: N/A - no event contract changed.
- Persistence flow changed? no
- Persistence policy evidence: N/A - no persistence flow changed.
- Broker Pub/Sub integration changed? no
- Broker decoupling policy evidence: N/A - no broker integration changed.
- Telemetry export or transport behavior changed? no
- Telemetry transport policy evidence: N/A - no telemetry behavior changed.
- Metric semantic design changed? no
- Metrics design policy evidence: N/A - no metrics changed.

## TDD Evidence
N/A - no production behavior changed. The PR adds fixture tests and hardens CI workflow dependency resolution.

## Validation
- command: `git branch --show-current`, fetch both remotes, verify the live head and base, and check fast-forward ancestry
  - scope: branch guard and fork ownership
  - result: pass, the branch was current, the base stayed at `4060f07`, and the fork belongs to `kriptoburak` with `Albe83/openapi-to-mcp` as parent.
- command: `.venv/bin/python -m pytest -q tests/unit/test_mapper.py tests/unit/test_tool_generator.py`
  - scope: Xquik mapper and generator fixture coverage
  - result: pass, 6 tests passed.
- command: `PATH="$PWD/.venv/bin:$PATH" make test`
  - scope: full repository suite
  - result: pass, 34 tests passed with 1 dependency deprecation warning.
- command: `.venv/bin/python -m ruff check src tests`
  - scope: Python source and tests
  - result: pass, all checks passed.
- command: `actionlint .github/workflows/security.yml .github/workflows/release.yml`
  - scope: changed GitHub Actions workflows
  - result: pass, no findings.
- command: `PATH="$PWD/.venv/bin:$PATH" make governance-check`
  - scope: repository governance
  - result: pass.
- command: YAML safe-load probe for both changed workflows and the Xquik fixture
  - scope: YAML syntax
  - result: pass, 3 documents parsed.
- command: `git diff --check`
  - scope: complete PR diff
  - result: pass.

## Compliance Map
| Module | Applies | Evidence Link or Command Result | N/A Reason |
| --- | --- | --- | --- |
| 02 | no |  | N/A - no feat or fix lifecycle applies. |
| 03 | no |  | N/A - no architecture decision changed. |
| 04 | yes | Focused and full tests pass. |  |
| 05 | yes | Branch, fork, base, ancestry, and Conventional Commits were verified. |  |
| 07 | yes | Tests, lint, actionlint, governance, YAML parsing, and diff checks pass. |  |
| 10 | yes | Author simplify and thermonuclear reviews found no findings. |  |

## Review Findings
- Author self-review completed: yes
- Independent review completed: no - waiting for maintainer review.
- Findings outcome: no findings

no findings

## Impact and Risk
- Scope of impact: tests and GitHub workflow dependency references only.
- Compatibility notes: no runtime code or public API changed.
- Rollout notes: no rollout action is needed.

## Checklist
- [x] PR targets `main`.
- [x] Existing branch remains short-lived and scoped to test and CI maintenance.
- [x] Conventional Commits used.
- [x] Task started on the correct branch and the base stayed unchanged.
- [x] No public API, model, persistence, container, telemetry, or logging behavior changed.
- [x] Matching tests and linters pass.
- [x] Author simplify and thermonuclear reviews completed.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
